### PR TITLE
Vylepšení bezpečnosti .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ SPSEGamingHub
 #### Production image
 
 ```
-docker run -d --name SPSEGamingHub -p 127.0.0.1:8080:80 -v /path/to/.env:/var/www/html/.env ghcr.io/spse-tournament/spsegaminghub:master
+docker run -d --name SPSEGamingHub -p 127.0.0.1:8080:80 -v /path/to/.env:/var/www/.env ghcr.io/spse-tournament/spsegaminghub:master
 ```
 
 #### Staging image
 
 ```
-docker run -d --name SPSEGamingHub -p 127.0.0.1:8080:80 -v /path/to/.env:/var/www/html/.env ghcr.io/spse-tournament/spsegaminghub:staging
+docker run -d --name SPSEGamingHub -p 127.0.0.1:8080:80 -v /path/to/.env:/var/www/.env ghcr.io/spse-tournament/spsegaminghub:staging
 ```
 
 ### Watchtower (optional, for automatic updates)

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ function autoLoad($cls) {
   }
 }
 spl_autoload_register("autoLoad");
-$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__, 1));
 $dotenv->load();
 Db::connect($_ENV['DB_HOST'], $_ENV['DB_USER'], $_ENV['DB_PW'], $_ENV['DB_DBNAME']);
 $router = new RouterController();


### PR DESCRIPTION
.env soubor nesmí být čitelný z HTTP rootu webserveru. Touto změnou byl přesunut o úroveň výše.